### PR TITLE
IMPCAP improvements

### DIFF
--- a/contrib/impcap/dns_parser.c
+++ b/contrib/impcap/dns_parser.c
@@ -204,14 +204,13 @@ static const char *get_class(uint16_t x) {
 
 
 /*
- *  This function parses the bytes in the received packet to extract SMB2 metadata.
+ *  This function parses the bytes in the received packet to extract DNS metadata.
  *
  *  its parameters are:
  *    - a pointer on the list of bytes representing the packet
- *        the beginning of the header will be checked by the function
  *    - the size of the list passed as first parameter
  *    - a pointer on a json_object, containing all the metadata recovered so far
- *      this is also where SMB2 metadata will be added
+ *      this is also where DNS metadata will be added
  *
  *  This function returns a structure containing the data unprocessed by this parser
  *  or the ones after (as a list of bytes), and the length of this data.

--- a/contrib/impcap/eth_parser.c
+++ b/contrib/impcap/eth_parser.c
@@ -159,10 +159,10 @@ data_ret_t* eth_parse(const uchar *packet, int pktSize, struct json_object *jpar
         /* packet has the minimum allowed size, so the remaining data is
          * most likely padding, this should not appear as data, so remove it
          * */
-        //TODO this is a quick win, a more elaborate solution would be to check if data
+        //TODO this is a quick win, a more elaborate solution would be to check if all data
         // is indeed zero, but that would take more processing time
-        if(pktSize <= 60) {
-            ret->size = 0;
+        if(pktSize <= 60 && ret->pData != NULL) {
+            if(!ret->pData[0]) ret->size = 0;
         }
         return ret;
     }
@@ -173,8 +173,8 @@ data_ret_t* eth_parse(const uchar *packet, int pktSize, struct json_object *jpar
 
     /* packet has the minimum allowed size, so the remaining data is
      * most likely padding, this should not appear as data, so remove it */
-    if(pktSize <= 60) {
-        ret->size = 0;
+    if(pktSize <= 60 && ret->pData != NULL) {
+        if(!ret->pData[0]) ret->size = 0;
     }
     return ret;
 }

--- a/contrib/impcap/ftp_parser.c
+++ b/contrib/impcap/ftp_parser.c
@@ -142,16 +142,8 @@ data_ret_t *ftp_parse(const uchar *packet, int pktSize, struct json_object *jpar
         free(packet2);
         if (code != 0) {
             json_object_object_add(jparent, "FTP_response", json_object_new_int(code));
-            int nb_digits = 1;
-            while( (code/=10) > 0 ) nb_digits++;
-            RETURN_DATA_AFTER(nb_digits)
-
         } else if (command != NULL) {
             json_object_object_add(jparent, "FTP_request", json_object_new_string(command));
-            RETURN_DATA_AFTER((int)strlen(command) + 1)
-
-        } else {
-            RETURN_DATA_AFTER(0)
         }
 	}
     RETURN_DATA_AFTER(0)

--- a/contrib/impcap/ftp_parser.c
+++ b/contrib/impcap/ftp_parser.c
@@ -135,20 +135,24 @@ data_ret_t *ftp_parse(const uchar *packet, int pktSize, struct json_object *jpar
 	uchar *frst_part_ftp;
 	frst_part_ftp = (uchar *)strtok((char *)packet2, " "); // Get first part of packet ftp
 	strtok(NULL, "\r\n");
-	int code = check_Code_ftp(frst_part_ftp);
-	const char *command = check_Command_ftp(frst_part_ftp);
-	free(packet2);
-	if (code != 0) {
-		json_object_object_add(jparent, "FTP_response", json_object_new_int(code));
-		int nb_digits = 1;
-		while( (code/=10) > 0 ) nb_digits++;
-		RETURN_DATA_AFTER(nb_digits)
 
-	} else if (command != NULL) {
-		json_object_object_add(jparent, "FTP_request", json_object_new_string(command));
-		RETURN_DATA_AFTER((int)strlen(command) + 1)
+	if(frst_part_ftp) {
+        int code = check_Code_ftp(frst_part_ftp);
+        const char *command = check_Command_ftp(frst_part_ftp);
+        free(packet2);
+        if (code != 0) {
+            json_object_object_add(jparent, "FTP_response", json_object_new_int(code));
+            int nb_digits = 1;
+            while( (code/=10) > 0 ) nb_digits++;
+            RETURN_DATA_AFTER(nb_digits)
 
-	} else {
-		RETURN_DATA_AFTER(0)
+        } else if (command != NULL) {
+            json_object_object_add(jparent, "FTP_request", json_object_new_string(command));
+            RETURN_DATA_AFTER((int)strlen(command) + 1)
+
+        } else {
+            RETURN_DATA_AFTER(0)
+        }
 	}
+    RETURN_DATA_AFTER(0)
 }

--- a/contrib/impcap/http_parser.c
+++ b/contrib/impcap/http_parser.c
@@ -154,10 +154,5 @@ data_ret_t* http_parse(const uchar *packet, int pktSize, struct json_object *jpa
     catch_status_and_fields(header, jparent);
 
     free(pHttp);
-    if(http) {
-        RETURN_DATA_AFTER((int)(http - header))
-    }
-    else {
-        RETURN_DATA_AFTER(0)
-    }
+    RETURN_DATA_AFTER(0)
 }

--- a/contrib/impcap/ipv6_parser.c
+++ b/contrib/impcap/ipv6_parser.c
@@ -32,12 +32,12 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wpacked"
 #pragma GCC diagnostic ignored "-Wattributes"
-struct __attribute__ ((__packed__)) ipv6_header_s {
+typedef struct __attribute__ ((__packed__)) ipv6_header_s {
 #ifndef IPV6_VERSION_MASK
-	#define IPV6_VERSION_MASK 0xF0000000
+	#define IPV6_VERSION_MASK   0xF0000000
 #endif
 #ifndef IPV6_TC_MASK
-	#define IPV6_TC_MASK			0x0FF00000
+    #define IPV6_TC_MASK		0x0FF00000
 #endif
 #ifndef IPV6_FLOW_MASK
 	#define IPV6_FLOW_MASK		0x000FFFFF
@@ -45,10 +45,23 @@ struct __attribute__ ((__packed__)) ipv6_header_s {
 	uint32_t vtf;
 	uint16_t dataLength;
 	uint8_t nextHeader;
+#define IPV6_NHDR_HBH     0
+#define IPV6_NHDR_TCP     6
+#define IPV6_NHDR_UDP     17
+#define IPV6_NHDR_ENCIP6  41
+#define IPV6_NHDR_ROUT    43
+#define IPV6_NHDR_FRAG    44
+#define IPV6_NHDR_RRSV    46
+#define IPV6_NHDR_SEC     50
+#define IPV6_NHDR_AUTH    51
+#define IPV6_NHDR_ICMP6   58
+#define IPV6_NHDR_NONHDR  59
+#define IPV6_NHDR_DOPTS   60
+
 	uint8_t hopLimit;
 	uint8_t addrSrc[16];
 	uint8_t addrDst[16];
-};
+} ipv6_header_t;
 #pragma GCC diagnostic pop
 
 #ifndef IPV6_VERSION
@@ -61,7 +74,114 @@ struct __attribute__ ((__packed__)) ipv6_header_s {
 	#define IPV6_FLOW(h)		(ntohl(h->vtf) & IPV6_FLOW_MASK)
 #endif
 
-typedef struct ipv6_header_s ipv6_header_t;
+/* extension headers */
+typedef struct hbh_header_s {
+    uint8_t nextHeader;
+    uint8_t hLength;
+    uint8_t *pOptions;
+}hbh_header_t;
+
+typedef struct dest_header_s {
+    uint8_t nextHeader;
+    uint8_t hLength;
+    uint8_t *pOptions;
+}dest_header_t;
+
+typedef struct route_header_s {
+    uint8_t nextHeader;
+    uint8_t hLength;
+    uint8_t rType;
+    uint8_t segsLeft;
+    uint32_t reserved;
+    uint8_t addrs[16];
+}route_header_t;
+
+typedef struct frag_header_s {
+    uint8_t nextHeader;
+    uint8_t reserved;
+    uint16_t offsetFlags;
+    uint32_t id;
+}frag_header_t;
+
+static inline uint8_t hbh_header_parse(uchar **packet, int *pktSize) {
+    DBGPRINTF("hbh_header_parse\n");
+    hbh_header_t *hbh_header = (hbh_header_t *)*packet;
+
+  /* hbh_header->hLength is the number of octets of header in 8-octet units minus 1
+   * the header length SHOULD be a multiple of 8 */
+  uint8_t hByteLength = hbh_header->hLength*8 + 8;
+  DBGPRINTF("hByteLength: %d\n", hByteLength);
+  *pktSize -= hByteLength;
+  *packet += hByteLength;
+
+  return hbh_header->nextHeader;
+}
+
+static inline uint8_t dest_header_parse(uchar **packet, int *pktSize) {
+    DBGPRINTF("dest_header_parse\n");
+    dest_header_t *dest_header = (dest_header_t *)*packet;
+
+    /* dest_header->hLength is the number of octets of header in 8-octet units minus 1
+     * the header length SHOULD be a multiple of 8 */
+    uint8_t hByteLength = dest_header->hLength*8 + 8;
+    DBGPRINTF("hByteLength: %d\n", hByteLength);
+    *pktSize -= hByteLength;
+    *packet += hByteLength;
+
+    return dest_header->nextHeader;
+}
+
+static inline uint8_t route_header_parse(uchar **packet, int *pktSize, struct json_object *jparent) {
+    DBGPRINTF("route_header_parse\n");
+    route_header_t *route_header = (route_header_t *)*packet;
+
+    /* route_header->hLength is the number of octets of header in 8-octet units minus 1
+    * the header length (in bytes) SHOULD be a multiple of 8 */
+    uint8_t hByteLength = route_header->hLength*8 + 8;
+    *pktSize -= hByteLength;
+    *packet += hByteLength;
+
+    if(route_header->rType == 0) {
+        json_object_object_add(jparent, "IP6_route_seg_left", json_object_new_int(route_header->segsLeft));
+
+        hByteLength -= 8;   //leave only length of routing addresses
+
+        char addrStr[40], routeFieldName[20];
+        int addrNum = 1;
+        uint8_t *addr = &route_header->addrs;
+
+        //while there is enough space for an IPv6 address
+        while(hByteLength >= 16) {
+            inet_ntop(AF_INET6, (void *)addr, addrStr, 40);
+            snprintf(routeFieldName, 20, "IP6_route_%d", addrNum++);
+            json_object_object_add(jparent, routeFieldName, json_object_new_string((char*)addrStr));
+
+            addr += 16;
+            hByteLength -= 16;
+        }
+    }
+
+    return route_header->nextHeader;
+}
+
+#define FRAG_OFFSET_MASK    0xFFF8
+#define MFLAG_MASK          0x0001
+static inline frag_header_parse(uchar **packet, int *pktSize, struct json_object *jparent) {
+    DBGPRINTF("frag_header_parse\n");
+
+    frag_header_t *frag_header = (frag_header_t *)*packet;
+
+    uint16_t flags = ntohs(frag_header->offsetFlags);
+
+    json_object_object_add(jparent, "IP6_frag_offset", json_object_new_int((flags & FRAG_OFFSET_MASK) >> 3));
+    json_object_object_add(jparent, "IP6_frag_more", json_object_new_boolean(flags & MFLAG_MASK));
+    json_object_object_add(jparent, "IP6_frag_id", json_object_new_int64(frag_header->id));
+
+    *pktSize -= 8;
+    *packet += 8;
+
+    return frag_header->nextHeader;
+}
 
 /*
  *	This function parses the bytes in the received packet to extract IPv6 metadata.
@@ -92,14 +212,34 @@ data_ret_t* ipv6_parse(const uchar *packet, int pktSize, struct json_object *jpa
 	inet_ntop(AF_INET6, (void *)&ipv6_header->addrSrc, addrSrc, 40);
 	inet_ntop(AF_INET6, (void *)&ipv6_header->addrDst, addrDst, 40);
 
-	json_object_object_add(jparent, "net_dst_ip", json_object_new_string((char*)addrDst));
-	json_object_object_add(jparent, "net_src_ip", json_object_new_string((char*)addrSrc));
-	json_object_object_add(jparent, "IP6_next_header", json_object_new_int(ipv6_header->nextHeader));
-	json_object_object_add(jparent, "net_ttl", json_object_new_int(ipv6_header->hopLimit));
+    json_object_object_add(jparent, "net_dst_ip", json_object_new_string((char*)addrDst));
+    json_object_object_add(jparent, "net_src_ip", json_object_new_string((char*)addrSrc));
+    json_object_object_add(jparent, "net_ttl", json_object_new_int(ipv6_header->hopLimit));
 
-	if (ipv6_header->nextHeader == 58) {
-		 return icmp_parse(packet+sizeof(ipv6_header_t),pktSize-sizeof(ipv6_header_t),jparent);
-	}
+    uint8_t nextHeader = ipv6_header->nextHeader;
 
-	RETURN_DATA_AFTER(40)
+    packet += sizeof(ipv6_header_t);
+    pktSize -= sizeof(ipv6_header_t);
+
+    DBGPRINTF("beginning ext headers scan\n");
+    uint8_t hasNext = 1;
+    do {
+        switch(nextHeader){
+            case IPV6_NHDR_HBH:     nextHeader = hbh_header_parse(&packet, &pktSize); break;
+            case IPV6_NHDR_TCP:     return tcp_parse(packet, pktSize, jparent);
+            case IPV6_NHDR_UDP:     return udp_parse(packet, pktSize, jparent);
+            case IPV6_NHDR_ENCIP6:  hasNext = 0; break;
+            case IPV6_NHDR_ROUT:    nextHeader = route_header_parse(&packet, &pktSize, jparent); break;
+            case IPV6_NHDR_FRAG:    nextHeader = frag_header_parse(&packet, &pktSize, jparent); break;
+            case IPV6_NHDR_RRSV:    hasNext = 0; break;
+            case IPV6_NHDR_SEC:     hasNext = 0; break;
+            case IPV6_NHDR_AUTH:    hasNext = 0; break;
+            case IPV6_NHDR_ICMP6:   return icmp_parse(packet, pktSize, jparent);
+            case IPV6_NHDR_NONHDR:  hasNext = 0; break;
+            case IPV6_NHDR_DOPTS:   nextHeader = dest_header_parse(&packet, &pktSize); break;
+            default:                hasNext = 0; break;
+        }
+    }while(hasNext);
+
+  RETURN_DATA_AFTER(0)
 }

--- a/contrib/impcap/smb_parser.c
+++ b/contrib/impcap/smb_parser.c
@@ -87,20 +87,23 @@ data_ret_t *smb_parse(const uchar *packet, int pktSize, struct json_object *jpar
 	DBGPRINTF("smb_parse\n");
 	DBGPRINTF("packet size %d\n", pktSize);
 
-	while (pktSize > 0) {
-		/* don't check packet[0] to include SMB version byte at the beginning */
-		if (packet[1] == 'S') {
-			if (packet[2] == 'M') {
-				if (packet[3] == 'B') {
+	int pktSizeCpy = pktSize;
+	uchar *packetCpy = packet;
+
+	while (pktSizeCpy > 0) {
+		/* don't check packetCpy[0] to include SMB version byte at the beginning */
+		if (packetCpy[1] == 'S') {
+			if (packetCpy[2] == 'M') {
+				if (packetCpy[3] == 'B') {
 					break;
 				}
 			}
 		}
-		packet++, pktSize--;
+		packetCpy++, pktSizeCpy--;
 	}
 
-	if ((int) pktSize < 64) {
-		DBGPRINTF("SMB packet too small : %d\n", pktSize);
+	if ((int) pktSizeCpy < 64) {
+		DBGPRINTF("SMB packet too small : %d\n", pktSizeCpy);
 		RETURN_DATA_AFTER(0)
 	}
 
@@ -110,7 +113,7 @@ data_ret_t *smb_parse(const uchar *packet, int pktSize, struct json_object *jpar
 		smb_header_t *hdr;
 	} smb_header_to_char;
 
-	smb_header_to_char.pck = packet;
+	smb_header_to_char.pck = packetCpy;
 	smb_header_t *smb_header = smb_header_to_char.hdr;
 	
 	char flags[5] = {0};

--- a/contrib/impcap/smb_parser.c
+++ b/contrib/impcap/smb_parser.c
@@ -136,5 +136,5 @@ data_ret_t *smb_parse(const uchar *packet, int pktSize, struct json_object *jpar
 	json_object_object_add(jparent, "SMB_treeID", json_object_new_int64(smb_header->treeID));
 	json_object_object_add(jparent, "SMB_userID", json_object_new_int64(userID));
 
-	RETURN_DATA_AFTER(smb_header->headerLength)
+	RETURN_DATA_AFTER(0)
 }

--- a/contrib/impcap/tcp_parser.c
+++ b/contrib/impcap/tcp_parser.c
@@ -31,6 +31,7 @@
 
 #define SMB_PORT 445
 #define HTTP_PORT 80
+#define HTTP_PORT_ALT 8080
 #define FTP_PORT 21
 #define FTP_PORT_DATA 20
 
@@ -104,15 +105,16 @@ data_ret_t *tcp_parse(const uchar *packet, int pktSize, struct json_object *jpar
 	json_object_object_add(jparent, "TCP_data_length", json_object_new_int(pktSize - headerLength));
 	json_object_object_add(jparent, "net_flags", json_object_new_string(flags));
 
-	if (srcPort == SMB_PORT || dstPort == SMB_PORT) {
-		return smb_parse(packet + headerLength, pktSize - headerLength, jparent);
-	}
-	if (srcPort == FTP_PORT || dstPort == FTP_PORT || srcPort == FTP_PORT_DATA || dstPort == FTP_PORT_DATA) {
-		return ftp_parse(packet + headerLength, pktSize - headerLength, jparent);
-	}
-	if (srcPort == HTTP_PORT || dstPort == HTTP_PORT) {
-		return http_parse(packet + headerLength, pktSize - headerLength, jparent);
-	}
-	DBGPRINTF("tcp return after 20\n");
-	RETURN_DATA_AFTER(headerLength)
+    if(srcPort == SMB_PORT || dstPort == SMB_PORT) {
+        return smb_parse(packet + headerLength, pktSize - headerLength, jparent);
+    }
+    if(srcPort == FTP_PORT || dstPort == FTP_PORT || srcPort == FTP_PORT_DATA || dstPort == FTP_PORT_DATA) {
+        return ftp_parse(packet + headerLength, pktSize - headerLength, jparent);
+    }
+    if(srcPort == HTTP_PORT || dstPort == HTTP_PORT ||
+    srcPort == HTTP_PORT_ALT || dstPort == HTTP_PORT_ALT){
+        return http_parse(packet + headerLength, pktSize - headerLength, jparent);
+    }
+    DBGPRINTF("tcp return after 20\n");
+    RETURN_DATA_AFTER(headerLength)
 }

--- a/contrib/impcap/tcp_parser.c
+++ b/contrib/impcap/tcp_parser.c
@@ -102,7 +102,6 @@ data_ret_t *tcp_parse(const uchar *packet, int pktSize, struct json_object *jpar
 	json_object_object_add(jparent, "net_dst_port", json_object_new_int(dstPort));
 	json_object_object_add(jparent, "TCP_seq_number", json_object_new_int64(ntohl(tcp_header->seq)));
 	json_object_object_add(jparent, "TCP_ack_number", json_object_new_int64(ntohl(tcp_header->ack)));
-	json_object_object_add(jparent, "TCP_data_length", json_object_new_int(pktSize - headerLength));
 	json_object_object_add(jparent, "net_flags", json_object_new_string(flags));
 
     if(srcPort == SMB_PORT || dstPort == SMB_PORT) {
@@ -115,6 +114,6 @@ data_ret_t *tcp_parse(const uchar *packet, int pktSize, struct json_object *jpar
     srcPort == HTTP_PORT_ALT || dstPort == HTTP_PORT_ALT){
         return http_parse(packet + headerLength, pktSize - headerLength, jparent);
     }
-    DBGPRINTF("tcp return after 20\n");
+    DBGPRINTF("tcp return after header length (%u)\n", headerLength);
     RETURN_DATA_AFTER(headerLength)
 }


### PR DESCRIPTION
# Various improvements to IMPCAP
## application-layer parsers modification
### heavy rework of HTTP parser
- fix various errors
- recover all header fields
### work on FTP
- fix various errors triggering segfaults

## IPv6
- get IP protocol from IPv6 packets
- handle most used IPv6 extended headers
- carry parsing to upper-layer parsers

## various improvements and changes
- handle and remove Ethernet padding
- add pcap timestamp to message
- return all application-layer data as packet data, regardless of parsing in these layers