### PR TITLE
omhiredis: Allow to define a name to instance and use it in logs

### DIFF
--- a/tests/omhiredis-dynakey.sh
+++ b/tests/omhiredis-dynakey.sh
@@ -17,6 +17,7 @@ template(name="dynakey" type="string" string="%$!dynaKey%")
 local4.* {
         set $!dynaKey = "myDynaKey";
         action(type="omhiredis"
+                name="omhiredis-dynakey"
                 server="127.0.0.1"
                 serverport="'$REDIS_RANDOM_PORT'"
                 mode="set"
@@ -50,6 +51,8 @@ export EXPECTED="/usr/bin/redis-cli
  msgnum:00000001:"
 
 cmp_exact $RSYSLOG_OUT_LOG
+
+content_check "omhiredis[omhiredis-dynakey]: trying connect to '127.0.0.1'" ${RSYSLOG_DYNNAME}.started
 
 stop_redis
 

--- a/tests/omhiredis-name-blank.sh
+++ b/tests/omhiredis-name-blank.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# added 2025-12-04 by Théo Bertin, released under ASL 2.0
+## Uncomment for debugging
+# export RS_REDIR=-d
+
+. ${srcdir:=.}/diag.sh init
+
+start_redis
+
+generate_conf
+add_conf '
+global(localhostname="server")
+module(load="../contrib/omhiredis/.libs/omhiredis")
+template(name="outfmt" type="string" string="%msg%")
+
+local4.* {
+        action(type="omhiredis"
+                server="127.0.0.1"
+                serverport="'$REDIS_RANDOM_PORT'"
+                mode="queue"
+                key="myKey"
+                template="outfmt")
+
+        stop
+}
+'
+
+startup
+
+injectmsg 1 1
+
+shutdown_when_empty
+wait_shutdown
+
+content_check "omhiredis[(null)]:" ${RSYSLOG_DYNNAME}.started
+check_not_present "omhiredis:" ${RSYSLOG_DYNNAME}.started
+stop_redis
+
+# Removes generated configuration file, log and pid files
+cleanup_redis
+
+exit_test

--- a/tests/omhiredis-publish.sh
+++ b/tests/omhiredis-publish.sh
@@ -15,6 +15,7 @@ template(name="outfmt" type="string" string="%msg%")
 
 local4.* {
         action(type="omhiredis"
+                name="omhiredis-publish"
                 server="127.0.0.1"
                 serverport="'$REDIS_RANDOM_PORT'"
                 mode="publish"
@@ -51,6 +52,8 @@ myChannel
  msgnum:00000003:"
 
 cmp_exact $RSYSLOG_OUT_LOG
+
+content_check "omhiredis[omhiredis-publish]: trying connect to '127.0.0.1'" ${RSYSLOG_DYNNAME}.started
 
 stop_redis
 

--- a/tests/omhiredis-queue-rpush.sh
+++ b/tests/omhiredis-queue-rpush.sh
@@ -15,6 +15,7 @@ template(name="outfmt" type="string" string="%msg%")
 
 local4.* {
         action(type="omhiredis"
+                name="omhiredis-queue-rpush"
                 server="127.0.0.1"
                 serverport="'$REDIS_RANDOM_PORT'"
                 mode="queue"
@@ -49,6 +50,8 @@ export EXPECTED="/usr/bin/redis-cli
  msgnum:00000005:"
 
 cmp_exact $RSYSLOG_OUT_LOG
+
+content_check "omhiredis[omhiredis-queue-rpush]: trying connect to '127.0.0.1'" ${RSYSLOG_DYNNAME}.started
 
 stop_redis
 

--- a/tests/omhiredis-queue.sh
+++ b/tests/omhiredis-queue.sh
@@ -15,6 +15,7 @@ template(name="outfmt" type="string" string="%msg%")
 
 local4.* {
         action(type="omhiredis"
+                name="omhiredis-queue"
                 server="127.0.0.1"
                 serverport="'$REDIS_RANDOM_PORT'"
                 mode="queue"
@@ -53,6 +54,8 @@ export EXPECTED="/usr/bin/redis-cli
  msgnum:00000001:"
 
 cmp_exact $RSYSLOG_OUT_LOG
+
+content_check "omhiredis[omhiredis-queue]: trying connect to '127.0.0.1'" ${RSYSLOG_DYNNAME}.started
 
 stop_redis
 

--- a/tests/omhiredis-set.sh
+++ b/tests/omhiredis-set.sh
@@ -15,6 +15,7 @@ template(name="outfmt" type="string" string="%msg%")
 
 local4.* {
         action(type="omhiredis"
+                name="omhiredis-set"
                 server="127.0.0.1"
                 serverport="'$REDIS_RANDOM_PORT'"
                 mode="set"
@@ -47,6 +48,8 @@ export EXPECTED="/usr/bin/redis-cli
  msgnum:00000001:"
 
 cmp_exact $RSYSLOG_OUT_LOG
+
+content_check "omhiredis[omhiredis-set]: trying connect to '127.0.0.1'" ${RSYSLOG_DYNNAME}.started
 
 stop_redis
 

--- a/tests/omhiredis-setex.sh
+++ b/tests/omhiredis-setex.sh
@@ -16,6 +16,7 @@ template(name="outfmt" type="string" string="%msg%")
 
 local4.* {
         action(type="omhiredis"
+                name="omhiredis-setex"
                 server="127.0.0.1"
                 serverport="'$REDIS_RANDOM_PORT'"
                 mode="set"
@@ -66,6 +67,8 @@ export EXPECTED="/usr/bin/redis-cli
 "
 
 cmp_exact $RSYSLOG_OUT_LOG
+
+content_check "omhiredis[omhiredis-setex]: trying connect to '127.0.0.1'" ${RSYSLOG_DYNNAME}.started
 
 stop_redis
 

--- a/tests/omhiredis-stream-ack.sh
+++ b/tests/omhiredis-stream-ack.sh
@@ -15,6 +15,7 @@ template(name="outfmt" type="string" string="%msg%")
 
 local4.* {
         action(type="omhiredis"
+                name="omhiredis-stream-ack"
                 server="127.0.0.1"
                 serverport="'$REDIS_RANDOM_PORT'"
                 mode="stream"
@@ -88,6 +89,9 @@ lag
 0"
 
 cmp_exact $RSYSLOG_OUT_LOG
+
+content_check "omhiredis[omhiredis-stream-ack]: no stream.outField set, using 'msg' as default" ${RSYSLOG_DYNNAME}.started
+content_check "omhiredis[omhiredis-stream-ack]: trying connect to '127.0.0.1'" ${RSYSLOG_DYNNAME}.started
 
 stop_redis
 

--- a/tests/omhiredis-stream-capped.sh
+++ b/tests/omhiredis-stream-capped.sh
@@ -15,6 +15,7 @@ template(name="outfmt" type="string" string="%msg%")
 
 local4.* {
         action(type="omhiredis"
+                name="omhiredis-stream-capped"
                 server="127.0.0.1"
                 serverport="'$REDIS_RANDOM_PORT'"
                 mode="stream"
@@ -44,6 +45,9 @@ if [ ! "${count}" -le 500 ]; then
     echo "error: stream has too much entries -> $count"
     error_exit 1
 fi
+
+content_check "omhiredis[omhiredis-stream-capped]: no stream.outField set, using 'msg' as default" ${RSYSLOG_DYNNAME}.started
+content_check "omhiredis[omhiredis-stream-capped]: trying connect to '127.0.0.1'" ${RSYSLOG_DYNNAME}.started
 
 stop_redis
 

--- a/tests/omhiredis-stream-del.sh
+++ b/tests/omhiredis-stream-del.sh
@@ -15,6 +15,7 @@ template(name="outfmt" type="string" string="%msg%")
 
 local4.* {
         action(type="omhiredis"
+                name="omhiredis-stream-del"
                 server="127.0.0.1"
                 serverport="'$REDIS_RANDOM_PORT'"
                 mode="stream"
@@ -61,6 +62,9 @@ value
 0"
 
 cmp_exact $RSYSLOG_OUT_LOG
+
+content_check "omhiredis[omhiredis-stream-del]: no stream.outField set, using 'msg' as default " ${RSYSLOG_DYNNAME}.started
+content_check "omhiredis[omhiredis-stream-del]: trying connect to '127.0.0.1'" ${RSYSLOG_DYNNAME}.started
 
 stop_redis
 

--- a/tests/omhiredis-stream-dynack.sh
+++ b/tests/omhiredis-stream-dynack.sh
@@ -22,6 +22,7 @@ local4.* {
         set $.redis!group = "myGroup";
         set $.redis!index = "2-0";
         action(type="omhiredis"
+                name="omhiredis-stream-ack"
                 server="127.0.0.1"
                 serverport="'$REDIS_RANDOM_PORT'"
                 mode="stream"
@@ -98,6 +99,9 @@ lag
 0"
 
 cmp_exact $RSYSLOG_OUT_LOG
+
+content_check "omhiredis[omhiredis-stream-ack]: no stream.outField set, using 'msg' as default" ${RSYSLOG_DYNNAME}.started
+content_check "omhiredis[omhiredis-stream-ack]: trying connect to '127.0.0.1'" ${RSYSLOG_DYNNAME}.started
 
 stop_redis
 

--- a/tests/omhiredis-stream-outfield.sh
+++ b/tests/omhiredis-stream-outfield.sh
@@ -15,6 +15,7 @@ template(name="outfmt" type="string" string="%msg%")
 
 local4.* {
         action(type="omhiredis"
+                name="omhiredis-stream-outfield"
                 server="127.0.0.1"
                 serverport="'$REDIS_RANDOM_PORT'"
                 mode="stream"
@@ -48,6 +49,8 @@ content_count_check " msgnum:00000002:" 1 $RSYSLOG_OUT_LOG
 content_count_check "custom_field" 2 $RSYSLOG_OUT_LOG
 content_count_check "msg" 2 $RSYSLOG_OUT_LOG
 content_count_check "msgnum" 2 $RSYSLOG_OUT_LOG
+
+content_check "omhiredis[omhiredis-stream-outfield]: trying connect to '127.0.0.1'" ${RSYSLOG_DYNNAME}.started
 
 stop_redis
 

--- a/tests/omhiredis-stream.sh
+++ b/tests/omhiredis-stream.sh
@@ -15,6 +15,7 @@ template(name="outfmt" type="string" string="%msg%")
 
 local4.* {
         action(type="omhiredis"
+                name="omhiredis-stream"
                 server="127.0.0.1"
                 serverport="'$REDIS_RANDOM_PORT'"
                 mode="stream"
@@ -54,6 +55,9 @@ content_count_check " msgnum:00000002:" 1 $RSYSLOG_OUT_LOG
 # 2 for the name of the field where the message was inserted, 2 for the 'msgnum' part
 content_count_check "msg" 4 $RSYSLOG_OUT_LOG
 content_count_check "msgnum" 2 $RSYSLOG_OUT_LOG
+
+content_check "omhiredis[omhiredis-stream]: no stream.outField set, using 'msg' as default" ${RSYSLOG_DYNNAME}.started
+content_check "omhiredis[omhiredis-stream]: trying connect to '127.0.0.1'" ${RSYSLOG_DYNNAME}.started
 
 stop_redis
 

--- a/tests/omhiredis-template.sh
+++ b/tests/omhiredis-template.sh
@@ -16,6 +16,7 @@ template(name="redis_command" type="string" string="INCRBY counter 3")
 
 local4.* {
         action(type="omhiredis"
+                name="omhiredis-template"
                 server="127.0.0.1"
                 serverport="'$REDIS_RANDOM_PORT'"
                 mode="template"
@@ -47,6 +48,8 @@ export EXPECTED="/usr/bin/redis-cli
 9"
 
 cmp_exact $RSYSLOG_OUT_LOG
+
+content_check "omhiredis[omhiredis-template]: trying connect to '127.0.0.1'" ${RSYSLOG_DYNNAME}.started
 
 stop_redis
 

--- a/tests/omhiredis-withpass.sh
+++ b/tests/omhiredis-withpass.sh
@@ -19,6 +19,7 @@ template(name="outfmt" type="string" string="%msg%")
 
 local4.* {
         action(type="omhiredis"
+                name="omhiredis-withpass"
                 server="127.0.0.1"
                 serverport="'$REDIS_RANDOM_PORT'"
                 serverpassword="'${REDIS_PASSWORD}'"
@@ -54,6 +55,8 @@ OK
  msgnum:00000001:"
 
 cmp_exact $RSYSLOG_OUT_LOG
+
+content_check "omhiredis[omhiredis-withpass]: trying connect to '127.0.0.1'" ${RSYSLOG_DYNNAME}.started
 
 stop_redis
 

--- a/tests/omhiredis-wrongpass.sh
+++ b/tests/omhiredis-wrongpass.sh
@@ -19,6 +19,7 @@ template(name="outfmt" type="string" string="%msg%")
 
 local4.* {
         action(type="omhiredis"
+                name="omhiredis-wrongpass"
                 server="127.0.0.1"
                 serverport="'$REDIS_RANDOM_PORT'"
                 serverpassword="ThatsNotMyPassword"
@@ -27,8 +28,6 @@ local4.* {
                 template="outfmt")
         stop
 }
-
-action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
 '
 
 startup
@@ -39,7 +38,9 @@ injectmsg 1 1
 shutdown_when_empty
 wait_shutdown
 
-content_check "error while authenticating: WRONGPASS invalid username-password pair or user is disabled." $RSYSLOG_OUT_LOG
+content_check "omhiredis[omhiredis-wrongpass]: trying connect to '127.0.0.1'" ${RSYSLOG_DYNNAME}.started
+content_check "omhiredis[omhiredis-wrongpass]: error while authenticating: WRONGPASS invalid username-password pair or user is disabled." ${RSYSLOG_DYNNAME}.started
+
 
 stop_redis
 


### PR DESCRIPTION
### Added
- [OMHIREDIS] New `name` instance parameter, used for internal Rsyslog logging 